### PR TITLE
Implementing support complex objects

### DIFF
--- a/examples/mle/main.go
+++ b/examples/mle/main.go
@@ -42,7 +42,7 @@ func main() {
 	state := generateId()
 	nonce := generateId()
 
-	opts := map[string]string{
+	opts := map[string]interface{}{
 		"acr_values": fmt.Sprintf("urn:signicat:oidc:method:ftn-op-auth"),
 		"ui_locales": "en",
 		"nonce":      nonce,

--- a/examples/normal/main.go
+++ b/examples/normal/main.go
@@ -58,7 +58,7 @@ func main() {
 	http.HandleFunc("/auth/", func(w http.ResponseWriter, r *http.Request) {
 		method := strings.Replace(r.URL.Path, "/auth/", "", 1)
 
-		opts := map[string]string{
+		opts := map[string]interface{}{
 			"acr_values": fmt.Sprintf("urn:signicat:oidc:method:%s", method),
 			"ui_locales": "fi",
 			"nonce":      nonce,

--- a/oidc.go
+++ b/oidc.go
@@ -22,7 +22,7 @@ import (
 type OIDCInterface interface {
 	Exchange(string, map[string]string) (*Tokens, error)
 	ExchangeWithNonce(string, string, map[string]string) (*Tokens, error)
-	AuthRequestURL(string, map[string]string) (string, error)
+	AuthRequestURL(string, map[string]interface{}) (string, error)
 	Verify(string) (*oidc.IDToken, error)
 	UserInfo(oauth2.TokenSource, interface{}) error
 	HandleCallback(string, string, url.Values, interface{}) error
@@ -174,10 +174,10 @@ func (o *OIDCClient) ExchangeWithNonce(code, nonce string, options map[string]st
 }
 
 // Returns the URL for authorization request.
-func (o *OIDCClient) AuthRequestURL(state string, options map[string]string) (string, error) {
+func (o *OIDCClient) AuthRequestURL(state string, options map[string]interface{}) (string, error) {
 	var opts []oauth2.AuthCodeOption
 	for key, value := range options {
-		opts = append(opts, oauth2.SetAuthURLParam(key, value))
+		opts = append(opts, oauth2.SetAuthURLParam(key, value.(string)))
 	}
 	return o.oauth2Config.AuthCodeURL(state, opts...), nil
 }
@@ -254,7 +254,7 @@ type OIDCClientEncrypted struct {
 }
 
 // Returns the authorization request URL with encrypted request object.
-func (o *OIDCClientEncrypted) AuthRequestURL(state string, opts map[string]string) (string, error) {
+func (o *OIDCClientEncrypted) AuthRequestURL(state string, opts map[string]interface{}) (string, error) {
 	mandatoryParams := map[string]string{
 		"response_type": "code",
 		"client_id":     o.oauth2Config.ClientID,

--- a/oidc_test.go
+++ b/oidc_test.go
@@ -214,7 +214,7 @@ var _ = Describe("OIDCClient tests", func() {
 	Describe("AuthRequestURL", func() {
 		It("returns authorization request url with correct parameters", func() {
 			state := generateId()
-			options := map[string]string{
+			options := map[string]interface{}{
 				"acr_values": "urn:signicat:oidc:method:ftn-op-auth",
 				"ui_locales": "fi",
 			}
@@ -1299,7 +1299,7 @@ var _ = Describe("OIDCClientEncrypted tests", func() {
 
 			acrValues := "urn:signicat:oidc:method:ftn-op-auth"
 			state := generateId()
-			opts := map[string]string{
+			opts := map[string]interface{}{
 				"acr_values": fmt.Sprintf(acrValues),
 				"ui_locales": "en",
 			}
@@ -1344,7 +1344,7 @@ var _ = Describe("OIDCClientEncrypted tests", func() {
 
 			acrValues := "urn:signicat:oidc:method:ftn-op-auth"
 			state := generateId()
-			opts := map[string]string{
+			opts := map[string]interface{}{
 				"acr_values": fmt.Sprintf(acrValues),
 				"ui_locales": "en",
 			}
@@ -1379,7 +1379,7 @@ var _ = Describe("OIDCClientEncrypted tests", func() {
 
 			acrValues := "urn:signicat:oidc:method:ftn-op-auth"
 			state := generateId()
-			opts := map[string]string{
+			opts := map[string]interface{}{
 				"acr_values": fmt.Sprintf(acrValues),
 				"ui_locales": "en",
 			}
@@ -1403,7 +1403,7 @@ var _ = Describe("OIDCClientEncrypted tests", func() {
 
 			acrValues := "urn:signicat:oidc:method:ftn-op-auth"
 			state := generateId()
-			opts := map[string]string{
+			opts := map[string]interface{}{
 				"acr_values": fmt.Sprintf(acrValues),
 				"ui_locales": "en",
 			}

--- a/oidc_test.go
+++ b/oidc_test.go
@@ -236,6 +236,32 @@ var _ = Describe("OIDCClient tests", func() {
 			Expect(parsedUrl.Query().Get("client_id")).To(Equal(config.ClientId))
 			Expect(parsedUrl.Path).To(Equal("/oidc/authorize"))
 		})
+
+		It("returns authorization request url with complex parameters", func() {
+			state := generateId()
+			options := map[string]interface{}{
+				"acr_values": "urn:signicat:oidc:method:ftn-op-auth",
+				"ui_locales": "fi",
+				"login_hints": []string{"birthday-121212", "phoneno-nnnnnnnn"},
+			}
+			ctx := context.Background()
+			client := Must(NewClient(context.WithValue(ctx, oauth2.HTTPClient, mockClient), &config))
+
+			authUrl, err := client.AuthRequestURL(state, options)
+			Expect(err).To(BeNil())
+			
+			parsedUrl, err := url.Parse(authUrl)
+			Expect(err).To(BeNil())
+
+			Expect(parsedUrl.Query().Get("redirect_uri")).To(Equal(config.RedirectUri))
+			Expect(parsedUrl.Query().Get("state")).To(Equal(state))
+			Expect(parsedUrl.Query().Get("response_type")).To(Equal("code"))
+			Expect(parsedUrl.Query().Get("scope")).To(Equal(strings.Join(config.Scopes, " ")))
+			Expect(parsedUrl.Query().Get("acr_values")).To(Equal(options["acr_values"]))
+			Expect(parsedUrl.Query().Get("ui_locales")).To(Equal(options["ui_locales"]))
+			Expect(parsedUrl.Query().Get("client_id")).To(Equal(config.ClientId))
+			Expect(parsedUrl.Path).To(Equal("/oidc/authorize"))
+		})
 	})
 
 	Describe("Exchange", func() {


### PR DESCRIPTION
When you are doing e.g. NO signing using nbid-inapp-sign you are required to send in `login_hints` as part of the payload. These login hints are just an array of strings. This means that the payload or `opts` in this case needs to support complex objects.

See https://developer.signicat.com/documentation/signing/signing-consent-signature/ or https://github.com/signicat/py-consent-sign/blob/master/nbid-consent-sign.py for more information.